### PR TITLE
Download with config

### DIFF
--- a/downloader_config.go
+++ b/downloader_config.go
@@ -1,0 +1,16 @@
+//
+// Copyright 2018 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package downloader
+
+import (
+	"net/http"
+)
+
+// Downloader is an asynchronous downloader
+type Config struct {
+	RequestHeaders               http.Header
+}


### PR DESCRIPTION
This PR aims to add a Config struct to pass to the `downloader.Download` function 

This way is possible to inject additional configuration for the http client created inside the function i.e. add http headers to the download request

Proper testing is included in the PR

Minor linting fixes are included notifyied by a quick `golangci-lint` run