### PR TITLE
use http client config to abstract proxy and default headers configurations

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -149,26 +148,7 @@ func DownloadWithConfig(file string, reqURL string, config Config, options ...Do
 		}
 	}
 
-	// apply Config
-
-	// Sets the header entries associated with key to
-	// the single element value. It replaces any existing
-	// values associated with key.
-	for k := range config.RequestHeaders {
-		req.Header.Set(k, config.RequestHeaders.Get(k))
-	}
-
-	client := &http.Client{}
-	if config.ProxyURL != "" {
-		proxy, err := url.Parse(config.ProxyURL)
-		if err != nil {
-			return nil, fmt.Errorf("invalid proxy %s: %s", config.ProxyURL, err)
-		}
-		client.Transport = &http.Transport{
-			Proxy: http.ProxyURL(proxy),
-		}
-	}
-	resp, err := client.Do(req)
+	resp, err := config.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/downloader_config.go
+++ b/downloader_config.go
@@ -13,12 +13,7 @@ import (
 
 // Config contains the configuration for the downloader
 type Config struct {
-	// RequestHeaders contains extra headers to add to the http request
-	RequestHeaders http.Header
-
-	// ProxyURL is the URL for a caching proxy to use to perform the request
-	// or empty string for no proxy
-	ProxyURL string
+	HttpClient http.Client
 }
 
 var defaultConfig Config = Config{}


### PR DESCRIPTION
By receiving a httpclient, the downloader can be made generic and unaware of proxy, default headers needed to be set by the user of this library.

