### PR TITLE
add v2 to module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.bug.st/downloader
+module go.bug.st/downloader/v2
 
 go 1.12
 


### PR DESCRIPTION
To be usable with go mod on users of this library, the module must have the v2 path