### PR TITLE
fix: Perform an HEAD call to get file info before the actual GET / fixed unit-tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+testdata/* text eol=lf

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -28,4 +28,5 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
+        shell: bash
         run: go test -race -coverprofile=coverage.txt -covermode=atomic

--- a/downloader.go
+++ b/downloader.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"time"
 )
@@ -137,14 +138,9 @@ func DownloadWithConfig(file string, reqURL string, config Config, options ...Do
 // in the specified file. A download resume is tried if a file shorter than the requested
 // url is already present. The download can be cancelled using the provided context.
 func DownloadWithConfigAndContext(ctx context.Context, file string, reqURL string, config Config, options ...DownloadOptions) (*Downloader, error) {
-	noResume := false
-	for _, opt := range options {
-		if opt == NoResume {
-			noResume = true
-		}
-	}
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	noResume := slices.Contains(options, NoResume)
 
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setting up HTTP request: %s", err)
 	}

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -73,6 +73,26 @@ func TestResume(t *testing.T) {
 	require.Equal(t, file1, file2)
 }
 
+func TestResumeOnAlreadyCompletedFile(t *testing.T) {
+	tmpFile := makeTmpFile(t)
+
+	full, err := os.ReadFile("testdata/test.txt")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tmpFile, full, 0644))
+
+	d, err := Download(tmpFile, "https://go.bug.st/test.txt")
+	require.NoError(t, err)
+	require.Equal(t, int64(8052), d.Completed())
+	require.Equal(t, int64(8052), d.Size())
+	require.NoError(t, d.Run())
+	require.Equal(t, int64(8052), d.Completed())
+
+	// Check file content is unchanged
+	file2, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	require.Equal(t, full, file2)
+}
+
 func TestNoResume(t *testing.T) {
 	tmpFile := makeTmpFile(t)
 

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -129,10 +129,8 @@ func TestRunAndPool(t *testing.T) {
 }
 
 func TestErrorOnFileOpening(t *testing.T) {
-	tmpFile := makeTmpFile(t)
-
-	require.NoError(t, os.WriteFile(tmpFile, []byte{}, 0000))
-	d, err := Download(tmpFile, "http://go.bug.st/test.txt")
+	unaccessibleFile := filepath.Join(os.TempDir(), "nonexistentdir", "test.txt")
+	d, err := Download(unaccessibleFile, "http://go.bug.st/test.txt")
 	require.Error(t, err)
 	require.Nil(t, d)
 }


### PR DESCRIPTION
This should solve part of the issue with servers not supporting Range headers.

Fixes #9 