### PR TITLE
By default, output error if status code is not 2xx

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -204,6 +204,17 @@ func DownloadWithConfigAndContext(ctx context.Context, file string, reqURL strin
 		return nil, err
 	}
 
+	// Check server response
+	if !config.DoNotErrorOnNon2xxStatusCode {
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+			_ = resp.Body.Close()
+			return &Downloader{
+				URL:  reqURL,
+				Resp: resp, // Return response for further inspection
+			}, fmt.Errorf("server returned %s", resp.Status)
+		}
+	}
+
 	// Open output file
 	flags := os.O_WRONLY
 	if resumeDownload {

--- a/downloader_config.go
+++ b/downloader_config.go
@@ -23,6 +23,9 @@ type Config struct {
 	// when the HTTP HEAD request is done, before starting the download.
 	// If the function returns an error, the download is aborted.
 	AcceptFunc func(head *http.Response) error
+	// DoNotErrorOnNon2xxStatusCode set to true to not return an error
+	// if the server returns a non-2xx status code.
+	DoNotErrorOnNon2xxStatusCode bool
 }
 
 var defaultConfig Config = Config{}


### PR DESCRIPTION
Previously, the download was performed anyway, in most cases resulting in a "404 - missing file" HTML page being downloaded instead of the expected file.