### PR TITLE
Implemented inactivity timeout (2nd take)

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -29,17 +29,6 @@ type Downloader struct {
 	wdog          watchdog
 }
 
-// Close the download
-func (d *Downloader) close() {
-	if d.out != nil {
-		d.out.Close()
-	}
-	if d.Resp != nil {
-		d.Resp.Body.Close()
-	}
-	d.wdog.Cancel()
-}
-
 // Size return the size of the download (or -1 if the server doesn't provide it)
 func (d *Downloader) Size() int64 {
 	return d.size
@@ -77,7 +66,11 @@ func (d *Downloader) Run() error {
 		return d.Error()
 	}
 
-	defer d.close()
+	defer func() {
+		d.out.Close()
+		d.Resp.Body.Close()
+		d.wdog.Cancel()
+	}()
 
 	in := d.Resp.Body
 	buff := [4096]byte{}

--- a/downloader.go
+++ b/downloader.go
@@ -25,6 +25,7 @@ type Downloader struct {
 	completedLock sync.Mutex
 	size          int64
 	err           error
+	timeout       time.Duration
 }
 
 // Close the download
@@ -135,6 +136,8 @@ func doHeadRequest(ctx context.Context, reqURL string, config Config) (*http.Res
 			headReq.Header.Set(k, v)
 		}
 	}
+	// Should complete the HEAD call within the inactivity timeout
+	config.HttpClient.Timeout = config.InactivityTimeout
 	headResp, err := config.HttpClient.Do(headReq)
 	if err != nil {
 		return nil, fmt.Errorf("performing HEAD request: %s", err)
@@ -248,5 +251,6 @@ func DownloadWithConfigAndContext(ctx context.Context, file string, reqURL strin
 		out:       f,
 		completed: completed,
 		size:      remoteSize,
+		timeout:   config.InactivityTimeout,
 	}, nil
 }

--- a/downloader_config.go
+++ b/downloader_config.go
@@ -9,6 +9,7 @@ package downloader
 import (
 	"net/http"
 	"sync"
+	"time"
 )
 
 // Config contains the configuration for the downloader
@@ -26,6 +27,9 @@ type Config struct {
 	// DoNotErrorOnNon2xxStatusCode set to true to not return an error
 	// if the server returns a non-2xx status code.
 	DoNotErrorOnNon2xxStatusCode bool
+	// InactivityTimeout is the duration after which, if no data is received,
+	// the download is aborted. If set to 0, no timeout is applied.
+	InactivityTimeout time.Duration
 }
 
 var defaultConfig Config = Config{}

--- a/watchdog.go
+++ b/watchdog.go
@@ -1,0 +1,50 @@
+//
+// Copyright 2025 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package downloader
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+type watchdog struct {
+	ctx     context.Context
+	cancel  context.CancelCauseFunc
+	timer   *time.Timer
+	timeout time.Duration
+}
+
+func newWatchdog(parent context.Context, timeout time.Duration) (context.Context, watchdog) {
+	ctx, cancel := context.WithCancelCause(parent)
+	var timer *time.Timer
+	if timeout > 0 {
+		timer = time.AfterFunc(timeout, func() {
+			// Cancel the context with a clear, standard error.
+			cancel(os.ErrDeadlineExceeded)
+		})
+	}
+	return ctx, watchdog{
+		ctx:     ctx,
+		cancel:  cancel,
+		timer:   timer,
+		timeout: timeout,
+	}
+}
+
+func (wd *watchdog) Kick() {
+	if wd.timeout > 0 {
+		wd.timer.Reset(wd.timeout)
+	}
+}
+
+func (wd *watchdog) Cancel() {
+	if wd.timeout > 0 {
+		wd.timer.Stop()
+	}
+	wd.cancel(nil)
+}


### PR DESCRIPTION
This time I've used the `context.WithCancelCause` abstraction, which makes the implementation more straightforward, and does not require the assumption `Close -> unlock Read` on `io.ReadCloser`.

Other improvements made:
* The HEAD call now lives in its own function
* Eliminated the redundant `Done` channel.
* Extensive unit-tests.