### PR TITLE
refactoring: Removed the Downloader object.

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -145,7 +146,10 @@ func DownloadWithConfig(ctx context.Context, file string, reqURL string, config 
 		completed.Store(localSize)
 	}
 	if config.PollFunction != nil {
+		var updateLock sync.Mutex
 		update := func() {
+			updateLock.Lock()
+			defer updateLock.Unlock()
 			config.PollFunction(completed.Load(), remoteSize)
 		}
 

--- a/downloader_config.go
+++ b/downloader_config.go
@@ -30,6 +30,11 @@ type Config struct {
 	// InactivityTimeout is the duration after which, if no data is received,
 	// the download is aborted. If set to 0, no timeout is applied.
 	InactivityTimeout time.Duration
+	// PollFunction is an optional function that will be called periodically
+	// during the download to report progress.
+	PollFunction func(current, size int64)
+	// PollInterval is the interval at which the PollFunction is called.
+	PollInterval time.Duration
 }
 
 var defaultConfig Config = Config{}

--- a/downloader_config.go
+++ b/downloader_config.go
@@ -33,7 +33,7 @@ type Config struct {
 	// PollFunction is an optional function that will be called periodically
 	// during the download to report progress.
 	PollFunction func(current, size int64)
-	// PollInterval is the interval at which the PollFunction is called.
+	// PollInterval is the interval at which the PollFunction is called (default is 250ms if not specified).
 	PollInterval time.Duration
 }
 

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -40,7 +40,7 @@ func TestDownload(t *testing.T) {
 	fullSize := int64(8052)
 	finalSize := int64(0)
 	count := 0
-	err := downloader.DownloadWithConfig(tmpFile, "https://go.bug.st/test.txt", downloader.Config{
+	err := downloader.DownloadWithConfig(t.Context(), tmpFile, "https://go.bug.st/test.txt", downloader.Config{
 		PollInterval: time.Second,
 		PollFunction: func(current, size int64) {
 			if count == 0 {
@@ -75,7 +75,7 @@ func TestResume(t *testing.T) {
 	fullSize := int64(8052)
 	finalSize := int64(0)
 	count := 0
-	err = downloader.DownloadWithConfig(tmpFile, "https://go.bug.st/test.txt", downloader.Config{
+	err = downloader.DownloadWithConfig(t.Context(), tmpFile, "https://go.bug.st/test.txt", downloader.Config{
 		PollInterval: time.Second,
 		PollFunction: func(current, size int64) {
 			if count == 0 {
@@ -109,7 +109,7 @@ func TestResumeOnAlreadyCompletedFile(t *testing.T) {
 	fullSize := int64(8052)
 	finalSize := int64(0)
 	count := 0
-	err = downloader.DownloadWithConfig(tmpFile, "https://go.bug.st/test.txt", downloader.Config{
+	err = downloader.DownloadWithConfig(t.Context(), tmpFile, "https://go.bug.st/test.txt", downloader.Config{
 		PollInterval: time.Second,
 		PollFunction: func(current, size int64) {
 			if count == 0 {
@@ -144,7 +144,7 @@ func TestNoResume(t *testing.T) {
 	fullSize := int64(8052)
 	finalSize := int64(0)
 	count := 0
-	err = downloader.DownloadWithConfig(tmpFile, "https://go.bug.st/test.txt", downloader.Config{
+	err = downloader.DownloadWithConfig(t.Context(), tmpFile, "https://go.bug.st/test.txt", downloader.Config{
 		DoNotResumeDownload: true,
 		PollInterval:        time.Second,
 		PollFunction: func(current, size int64) {
@@ -171,7 +171,7 @@ func TestNoResume(t *testing.T) {
 func TestInvalidRequest(t *testing.T) {
 	tmpFile := makeTmpFile(t)
 
-	err := downloader.Download(tmpFile, "asd://go.bug.st/test.txt")
+	err := downloader.Download(t.Context(), tmpFile, "asd://go.bug.st/test.txt")
 	require.Error(t, err)
 	fmt.Println("ERROR:", err)
 }
@@ -190,7 +190,7 @@ func TestRunAndPool(t *testing.T) {
 	config := downloader.GetDefaultConfig()
 	config.PollFunction = callback
 	config.PollInterval = time.Millisecond
-	err := downloader.DownloadWithConfig(tmpFile, "https://downloads.arduino.cc/cores/avr-1.6.20.tar.bz2", config)
+	err := downloader.DownloadWithConfig(t.Context(), tmpFile, "https://downloads.arduino.cc/cores/avr-1.6.20.tar.bz2", config)
 	require.NoError(t, err)
 	fmt.Printf("callback called %d times\n", callCount)
 	require.Greater(t, callCount, 10)
@@ -199,7 +199,7 @@ func TestRunAndPool(t *testing.T) {
 
 func TestErrorOnFileOpening(t *testing.T) {
 	unaccessibleFile := filepath.Join(os.TempDir(), "nonexistentdir", "test.txt")
-	err := downloader.Download(unaccessibleFile, "http://go.bug.st/test.txt")
+	err := downloader.Download(t.Context(), unaccessibleFile, "http://go.bug.st/test.txt")
 	require.Error(t, err)
 }
 
@@ -207,7 +207,7 @@ func TestErrorOnFileOpening(t *testing.T) {
 func TestApplyUserAgentHeaderUsingConfig(t *testing.T) {
 	tmpFile := makeTmpFile(t)
 
-	err := downloader.DownloadWithConfig(tmpFile, "https://postman-echo.com/headers", downloader.Config{
+	err := downloader.DownloadWithConfig(t.Context(), tmpFile, "https://postman-echo.com/headers", downloader.Config{
 		ExtraHeaders: map[string]string{
 			"User-Agent": "go-downloader / 0.0.0-test",
 		},
@@ -259,7 +259,7 @@ func TestContextCancelation(t *testing.T) {
 	}()
 
 	// Run slow download
-	err := downloader.DownloadWithConfigAndContext(ctx, tmpFile, server.URL+"/slow", downloader.Config{
+	err := downloader.DownloadWithConfig(ctx, tmpFile, server.URL+"/slow", downloader.Config{
 		PollInterval: 100 * time.Millisecond,
 		PollFunction: callback,
 	})
@@ -285,7 +285,7 @@ func TestTimeoutOnHEADCall(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	err := downloader.DownloadWithConfig(tmpFile, server.URL+"/timeout", config)
+	err := downloader.DownloadWithConfig(t.Context(), tmpFile, server.URL+"/timeout", config)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context deadline exceeded")
 	elapsed := time.Since(startTime)
@@ -313,7 +313,7 @@ func TestTimeoutOnGETCall(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	err := downloader.DownloadWithConfig(tmpFile, server.URL+"/slow", config)
+	err := downloader.DownloadWithConfig(t.Context(), tmpFile, server.URL+"/slow", config)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "i/o timeout")
 	elapsed := time.Since(startTime)
@@ -358,7 +358,7 @@ func TestInactivityTimeout(t *testing.T) {
 	// (should timeout due to inactivity)
 	tmpFile := makeTmpFile(t)
 	startTime := time.Now()
-	err := downloader.DownloadWithConfigAndContext(
+	err := downloader.DownloadWithConfig(
 		t.Context(), tmpFile, server.URL+"/inactive",
 		downloader.Config{
 			InactivityTimeout: 500 * time.Millisecond,

--- a/examples/check_download_size/main.go
+++ b/examples/check_download_size/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 )
 
 func main() {
-	if err := downloader.DownloadWithConfig("test.txt", "https://go.bug.st/test.txt", downloader.Config{
+	if err := downloader.DownloadWithConfig(context.Background(), "test.txt", "https://go.bug.st/test.txt", downloader.Config{
 		AcceptFunc: func(head *http.Response) error {
 			if head.ContentLength > 2000 {
 				return fmt.Errorf("insufficient space for download")

--- a/examples/check_download_size/main.go
+++ b/examples/check_download_size/main.go
@@ -15,15 +15,14 @@ import (
 )
 
 func main() {
-	_, err := downloader.DownloadWithConfig("test.txt", "https://go.bug.st/test.txt", downloader.Config{
+	if err := downloader.DownloadWithConfig("test.txt", "https://go.bug.st/test.txt", downloader.Config{
 		AcceptFunc: func(head *http.Response) error {
 			if head.ContentLength > 2000 {
 				return fmt.Errorf("insufficient space for download")
 			}
 			return nil
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/download_file/main.go
+++ b/examples/download_file/main.go
@@ -23,15 +23,17 @@ func main() {
 	}
 	defer os.RemoveAll(tmp)
 
-	d, err := downloader.Download(filepath.Join(tmp, "test.txt"), "https://go.bug.st/test.txt")
+	d, err := downloader.DownloadWithConfig(filepath.Join(tmp, "test.txt"), "https://go.bug.st/test.txt", downloader.Config{
+		PollInterval: time.Millisecond,
+		PollFunction: func(current, size int64) {
+			fmt.Printf("Downloaded %d / %d bytes (%.2f%%)\n", current, size, float64(current)*100.0/float64(size))
+		},
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	progressCB := func(current int64) {
-		fmt.Printf("Downloaded %d / %d bytes (%.2f%%)\n", current, d.Size(), float64(current)*100.0/float64(d.Size()))
-	}
-	if err := d.RunAndPoll(progressCB, time.Millisecond); err != nil {
+	if err := d.Run(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/download_file/main.go
+++ b/examples/download_file/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -23,12 +24,16 @@ func main() {
 	}
 	defer os.RemoveAll(tmp)
 
-	if err := downloader.DownloadWithConfig(filepath.Join(tmp, "test.txt"), "https://go.bug.st/test.txt", downloader.Config{
-		PollInterval: time.Millisecond,
-		PollFunction: func(current, size int64) {
-			fmt.Printf("Downloaded %d / %d bytes (%.2f%%)\n", current, size, float64(current)*100.0/float64(size))
-		},
-	}); err != nil {
+	if err := downloader.DownloadWithConfig(
+		context.Background(),
+		filepath.Join(tmp, "test.txt"),
+		"https://go.bug.st/test.txt",
+		downloader.Config{
+			PollInterval: time.Millisecond,
+			PollFunction: func(current, size int64) {
+				fmt.Printf("Downloaded %d / %d bytes (%.2f%%)\n", current, size, float64(current)*100.0/float64(size))
+			},
+		}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/download_file/main.go
+++ b/examples/download_file/main.go
@@ -23,17 +23,12 @@ func main() {
 	}
 	defer os.RemoveAll(tmp)
 
-	d, err := downloader.DownloadWithConfig(filepath.Join(tmp, "test.txt"), "https://go.bug.st/test.txt", downloader.Config{
+	if err := downloader.DownloadWithConfig(filepath.Join(tmp, "test.txt"), "https://go.bug.st/test.txt", downloader.Config{
 		PollInterval: time.Millisecond,
 		PollFunction: func(current, size int64) {
 			fmt.Printf("Downloaded %d / %d bytes (%.2f%%)\n", current, size, float64(current)*100.0/float64(size))
 		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if err := d.Run(); err != nil {
+	}); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
After a number of iterations, I found that the original design with a Downloader object was not worth it. Since we are making a breaking change, let's do it for good.

In this PR, I've removed the Downloader object, and I've changed the two-step process (creating the Downloader object and calling the Run method on it) into a single function call to Download.

Other small changes in this PR:
* Removed the Download function without the context, and harmonized the existing ones.
* Added a default value for PollInterval.
* Exploited the new design to improve the readability of the implementation.